### PR TITLE
Bump mammoth-test-helpers to v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-maybe-import-regenerator": "",
     "ember-resolver": "^4.0.0",
     "ember-source": "^3.0.0",
-    "mammoth-test-helpers": "^0.12.0",
+    "mammoth-test-helpers": "v0.13.0",
     "loader.js": "^4.2.3",
     "eslint": "^3.18.0",
     "eslint-config-mammoth": "0.1.0",


### PR DESCRIPTION
This will bump the mammoth-test-helpers dependency to version v0.13.0


- [ ] Run `yarn install` and commit changes yarn.lock